### PR TITLE
feat: add block 27 (trace alignment / BAM) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SnapGene File Format Parser
 
-A reverse-engineered parser and writer for SnapGene `.dna` files (DNA, RNA, protein). Supports all 16 known block types with typed Python models, a chainable builder pattern, and a history operations API.
+A reverse-engineered parser and writer for SnapGene `.dna` files (DNA, RNA, protein). Supports all 17 known block types with typed Python models, a chainable builder pattern, and a history operations API.
 
 > [!Important]
 > Found an unknown block type? Run `sff check your_file.dna -l` — blocks marked `[NEW]` are genuinely unknown, `[*]` are known but undecoded. Please report `[NEW]` blocks in [#1](https://github.com/merv1n34k/sgffp/issues/1) with a dump (`sff check your_file.dna -d`).
@@ -86,6 +86,7 @@ SnapGene files use a **TLV (Type-Length-Value)** binary format after a 19-byte h
 | 20 | Strand Colors | XML | |
 | 21 | Protein Sequence | UTF-8 | SgffSequence |
 | 23 | File Attachments | Binary + zlib XML | SgffAttachmentList |
+| 27 | Trace Alignment | BGZF + BAM | SgffTraceAlignment |
 | 28 | Enzyme Visibilities | XML | |
 | 29 | History Modifier | LZMA + XML | SgffHistory |
 | 30 | History Content | LZMA + TLV | SgffHistory |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -47,9 +47,9 @@ sff info [input] [-v]
 
 ### Output
 
-Basic mode shows: file type, sequence length/topology/strandedness, feature/primer/trace/attachment/history counts, block IDs present.
+Basic mode shows: file type, sequence length/topology/strandedness, feature/primer/trace/trace alignment/attachment/history counts, block IDs present.
 
-Verbose mode (`-v`) additionally shows: notes (description, created, modified), feature list with strand/type/positions, primer list, trace details, attachment list, history tree.
+Verbose mode (`-v`) additionally shows: notes (description, created, modified), feature list with strand/type/positions, primer list, trace details, trace alignment (SAM header, references, per-record CIGAR/strand/position), attachment list, history tree.
 
 ### Examples
 

--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -423,6 +423,33 @@ Embeds arbitrary files (images, documents) inside the `.dna` file. Two sub-forma
 
 **Discrimination:** if the first 4 bytes are zero, the block is a manifest; otherwise it is file data.
 
+### Block 27 — Trace Alignment (BGZF BAM)
+
+Stores alignment of sequencing traces (block 16) against the reference sequence as BGZF-compressed BAM data.
+
+**BGZF structure:** Concatenated gzip blocks, each with a BC extra field containing the block size (BSIZE). Ends with a standard 28-byte EOF marker.
+
+| Component | Description |
+|-----------|-------------|
+| Header block | BAM magic (`BAM\x01`) + SAM header text + reference sequences |
+| Data block(s) | Alignment records (one per trace) |
+| EOF block | 28-byte empty gzip block (standard BAM EOF marker) |
+
+**BAM header:**
+
+| Offset | Size | Description |
+|--------|------|-------------|
+| 0 | 4 | Magic `BAM\x01` |
+| 4 | 4 | `l_text` — SAM header length (little-endian int32) |
+| 8 | l_text | SAM header text (e.g. `@HD\tVN:1.6\tSO::unsorted\n`) |
+| 8+l_text | 4 | `n_ref` — number of reference sequences |
+
+Per reference: `l_name` (int32) + name (null-terminated) + `l_ref` (int32, sequence length).
+
+**Alignment record fields:** `ref_id`, `pos`, `mapq`, `bin`, `flag`, CIGAR ops, 4-bit packed sequence, quality scores, auxiliary tags.
+
+**Relationship with block 17:** Block 17 (`AlignableSequences` XML) holds alignment metadata — trim range, display settings. Block 27 holds the actual BAM data. They are linked by ID: block 17's `Sequence/@ID` matches block 27's BAM record `read_name`.
+
 ### Block 28 — Enzyme Visibilities (XML)
 
 Override enzyme visibility. Top-level element: `<EnzymeVisibilities>`.

--- a/docs/reference/other-models.md
+++ b/docs/reference/other-models.md
@@ -221,3 +221,58 @@ for att in sgff.attachments:
 sgff.add_attachment("gel.jpg", open("gel.jpg", "rb").read())
 att = sgff.attachments.get_by_name("gel.jpg")
 ```
+
+---
+
+## SgffTraceAlignment
+
+Trace alignment data (block 27). Inherits from `SgffModel`. Contains BGZF-compressed BAM data — alignments of sequencing traces against the reference sequence.
+
+```python
+from sgffp import SgffTraceAlignment, SgffBamRecord, SgffBamReference
+```
+
+**BLOCK_IDS:** `(27,)`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `header` | `str` | SAM header text |
+| `references` | `List[SgffBamReference]` | Reference sequences |
+| `records` | `List[SgffBamRecord]` | Alignment records |
+| `record_count` | `int` | Number of alignment records |
+| `reference_count` | `int` | Number of reference sequences |
+
+### SgffBamReference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `str` | `""` | Reference name |
+| `length` | `int` | `0` | Reference length in bp |
+
+### SgffBamRecord
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `read_name` | `str` | `""` | Read/trace name (matches block 17 Sequence/@ID) |
+| `flag` | `int` | `0` | SAM flag bits |
+| `ref_id` | `int` | `0` | Reference sequence index |
+| `pos` | `int` | `0` | 0-based mapping position |
+| `mapq` | `int` | `255` | Mapping quality |
+| `cigar` | `str` | `""` | CIGAR string (e.g. `3S154M6S`) |
+| `sequence` | `str` | `""` | Read sequence |
+| `quality` | `List[int]` | `[]` | Per-base quality scores |
+
+Properties: `is_unmapped`, `is_reverse`, `length`.
+
+### Example
+
+```python
+if sgff.has_trace_alignment:
+    ta = sgff.trace_alignment
+    print(f"SAM header: {ta.header}")
+    for ref in ta.references:
+        print(f"  Reference: {ref.name} ({ref.length} bp)")
+    for rec in ta.records:
+        strand = "reverse" if rec.is_reverse else "forward"
+        print(f"  {rec.read_name}: {strand}, CIGAR={rec.cigar}, {rec.length}bp")
+```

--- a/docs/reference/sgff-object.md
+++ b/docs/reference/sgff-object.md
@@ -49,6 +49,7 @@ All lazily loaded and cached. Call `invalidate()` to reset.
 | `alignments` | `SgffAlignmentList` | Alignable sequences |
 | `traces` | `SgffTraceList` | Chromatogram traces |
 | `attachments` | `SgffAttachmentList` | File attachments |
+| `trace_alignment` | `SgffTraceAlignment` | Trace alignment (BAM) data |
 | `ops` | `SgffOps` | Operations API |
 
 ### Existence Checks
@@ -63,6 +64,7 @@ All lazily loaded and cached. Call `invalidate()` to reset.
 | `has_alignments` | 17 |
 | `has_traces` | 16 |
 | `has_attachments` | 23 |
+| `has_trace_alignment` | 27 |
 
 ### Block Access Methods
 

--- a/src/sgffp/__init__.py
+++ b/src/sgffp/__init__.py
@@ -31,6 +31,9 @@ from .models import (
     SgffTraceSamples,
     SgffAttachment,
     SgffAttachmentList,
+    SgffTraceAlignment,
+    SgffBamRecord,
+    SgffBamReference,
     SgffOps,
 )
 
@@ -65,5 +68,8 @@ __all__ = [
     "SgffTraceSamples",
     "SgffAttachment",
     "SgffAttachmentList",
+    "SgffTraceAlignment",
+    "SgffBamRecord",
+    "SgffBamReference",
     "SgffOps",
 ]

--- a/src/sgffp/cli.py
+++ b/src/sgffp/cli.py
@@ -91,6 +91,10 @@ def cmd_info(args):
     if sgff.has_traces:
         print(f"Traces: {len(sgff.traces)}")
 
+    # Trace alignment
+    if sgff.has_trace_alignment:
+        print(f"Trace alignment: {sgff.trace_alignment.record_count} records")
+
     # Attachments
     if sgff.has_attachments:
         print(f"Attachments: {len(sgff.attachments)}")
@@ -138,6 +142,17 @@ def cmd_info(args):
         print(f"\n--- Traces ({len(sgff.traces)}) ---")
         for i, t in enumerate(sgff.traces, 1):
             print(f"  Trace {i}: {t.length} bases, {t.sample_count} samples")
+
+    # Trace alignment
+    if sgff.has_trace_alignment:
+        ta = sgff.trace_alignment
+        print(f"\n--- Trace Alignment ({ta.record_count} records) ---")
+        print(f"  SAM header: {ta.header.strip()}")
+        for ref in ta.references:
+            print(f"  Reference: {ref.name} ({ref.length} bp)")
+        for rec in ta.records:
+            strand = "reverse" if rec.is_reverse else "forward"
+            print(f"  Record: {rec.read_name}, {strand}, CIGAR={rec.cigar}, {rec.length}bp, pos={rec.pos}")
 
     # Attachments
     if sgff.has_attachments:

--- a/src/sgffp/internal.py
+++ b/src/sgffp/internal.py
@@ -20,6 +20,7 @@ from .models import (
     SgffTraceList,
     SgffAttachment,
     SgffAttachmentList,
+    SgffTraceAlignment,
 )
 
 
@@ -114,6 +115,7 @@ class SgffObject:
         self._alignments: Optional[SgffAlignmentList] = None
         self._traces: Optional[SgffTraceList] = None
         self._attachments: Optional[SgffAttachmentList] = None
+        self._trace_alignment: Optional[SgffTraceAlignment] = None
         self._ops = None
 
     def invalidate(self) -> None:
@@ -127,6 +129,7 @@ class SgffObject:
         self._alignments = None
         self._traces = None
         self._attachments = None
+        self._trace_alignment = None
         self._ops = None
 
     @property
@@ -239,6 +242,13 @@ class SgffObject:
         return self._attachments
 
     @property
+    def trace_alignment(self) -> SgffTraceAlignment:
+        """Trace alignment (BAM) data."""
+        if self._trace_alignment is None:
+            self._trace_alignment = SgffTraceAlignment(self.blocks)
+        return self._trace_alignment
+
+    @property
     def ops(self):
         """Operations API for recording history changes."""
         if self._ops is None:
@@ -278,6 +288,10 @@ class SgffObject:
     @property
     def has_attachments(self) -> bool:
         return 23 in self.blocks
+
+    @property
+    def has_trace_alignment(self) -> bool:
+        return 27 in self.blocks
 
     def add_feature(
         self,

--- a/src/sgffp/models/__init__.py
+++ b/src/sgffp/models/__init__.py
@@ -21,6 +21,7 @@ from .properties import SgffProperties
 from .alignment import SgffAlignment, SgffAlignmentList
 from .trace import SgffTrace, SgffTraceList, SgffTraceClip, SgffTraceSamples
 from .attachment import SgffAttachment, SgffAttachmentList
+from .trace_alignment import SgffTraceAlignment, SgffBamRecord, SgffBamReference
 from .ops import SgffOps
 
 __all__ = [
@@ -51,5 +52,8 @@ __all__ = [
     "SgffTraceSamples",
     "SgffAttachment",
     "SgffAttachmentList",
+    "SgffTraceAlignment",
+    "SgffBamRecord",
+    "SgffBamReference",
     "SgffOps",
 ]

--- a/src/sgffp/models/trace_alignment.py
+++ b/src/sgffp/models/trace_alignment.py
@@ -1,0 +1,140 @@
+"""
+Trace alignment model (block 27) — BGZF-compressed BAM data
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Any, Optional
+
+from .base import SgffModel
+
+
+@dataclass
+class SgffBamReference:
+    """BAM reference sequence entry."""
+
+    name: str = ""
+    length: int = 0
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SgffBamReference":
+        return cls(name=data.get("name", ""), length=data.get("length", 0))
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"name": self.name, "length": self.length}
+
+
+@dataclass
+class SgffBamRecord:
+    """Single BAM alignment record."""
+
+    read_name: str = ""
+    flag: int = 0
+    ref_id: int = 0
+    pos: int = 0
+    mapq: int = 255
+    cigar: str = ""
+    sequence: str = ""
+    quality: List[int] = field(default_factory=list)
+    next_ref_id: int = 0
+    next_pos: int = 0
+    tlen: int = 0
+    bin: int = 0
+    aux: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_unmapped(self) -> bool:
+        return bool(self.flag & 0x4)
+
+    @property
+    def is_reverse(self) -> bool:
+        return bool(self.flag & 0x10)
+
+    @property
+    def length(self) -> int:
+        return len(self.sequence)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SgffBamRecord":
+        return cls(
+            read_name=data.get("read_name", ""),
+            flag=data.get("flag", 0),
+            ref_id=data.get("ref_id", 0),
+            pos=data.get("pos", 0),
+            mapq=data.get("mapq", 255),
+            cigar=data.get("cigar", ""),
+            sequence=data.get("sequence", ""),
+            quality=data.get("quality", []),
+            next_ref_id=data.get("next_ref_id", 0),
+            next_pos=data.get("next_pos", 0),
+            tlen=data.get("tlen", 0),
+            bin=data.get("bin", 0),
+            aux=data.get("aux", {}),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "read_name": self.read_name,
+            "flag": self.flag,
+            "ref_id": self.ref_id,
+            "pos": self.pos,
+            "mapq": self.mapq,
+            "cigar": self.cigar,
+            "sequence": self.sequence,
+            "quality": self.quality,
+            "next_ref_id": self.next_ref_id,
+            "next_pos": self.next_pos,
+            "tlen": self.tlen,
+            "bin": self.bin,
+            "aux": self.aux,
+        }
+
+
+class SgffTraceAlignment(SgffModel):
+    """Trace alignment data (block 27) — BAM alignments of traces against reference."""
+
+    BLOCK_IDS = (27,)
+
+    def __init__(self, blocks: Dict[int, List[Any]]):
+        super().__init__(blocks)
+        self._data: Optional[Dict] = None
+
+    def _load(self) -> Dict:
+        data = self._get_block(27)
+        if data:
+            return data
+        return {"header": "", "references": [], "records": []}
+
+    @property
+    def data(self) -> Dict:
+        if self._data is None:
+            self._data = self._load()
+        return self._data
+
+    @property
+    def header(self) -> str:
+        return self.data.get("header", "")
+
+    @property
+    def references(self) -> List[SgffBamReference]:
+        return [SgffBamReference.from_dict(r) for r in self.data.get("references", [])]
+
+    @property
+    def records(self) -> List[SgffBamRecord]:
+        return [SgffBamRecord.from_dict(r) for r in self.data.get("records", [])]
+
+    @property
+    def record_count(self) -> int:
+        return len(self.data.get("records", []))
+
+    @property
+    def reference_count(self) -> int:
+        return len(self.data.get("references", []))
+
+    def _sync(self) -> None:
+        if self._data:
+            self._set_block(27, self._data)
+        else:
+            self._remove_block(27)
+
+    def __repr__(self) -> str:
+        return f"SgffTraceAlignment(references={self.reference_count}, records={self.record_count})"

--- a/src/sgffp/parsers.py
+++ b/src/sgffp/parsers.py
@@ -3,6 +3,7 @@ Block type parsers and parsing scheme
 """
 
 import struct
+import gzip
 import lzma
 import logging
 import json
@@ -569,6 +570,198 @@ def parse_history_node(data: bytes) -> Dict[str, Any]:
 
 
 # =============================================================================
+# TRACE ALIGNMENT (BAM/BGZF) PARSER
+# =============================================================================
+
+BAM_MAGIC = b"BAM\x01"
+_BAM_SEQ_BASES = "=ACMGRSVTWYHKDBN"
+_BAM_CIGAR_OPS = "MIDNSHP=X"
+
+
+def _decompress_bgzf(data: bytes) -> bytes:
+    """Decompress BGZF (blocked gzip) data into raw BAM bytes."""
+    result = bytearray()
+    offset = 0
+    while offset < len(data):
+        if data[offset : offset + 2] != b"\x1f\x8b":
+            break
+        # BSIZE in BC extra field at offset 16-17
+        bsize = struct.unpack("<H", data[offset + 16 : offset + 18])[0]
+        block = data[offset : offset + bsize + 1]
+        decompressed = gzip.decompress(block)
+        result.extend(decompressed)
+        offset += bsize + 1
+    return bytes(result)
+
+
+def _decode_bam_seq(data: bytes, l_seq: int) -> str:
+    """Decode 4-bit packed BAM sequence to string."""
+    result = []
+    for b in data:
+        result.append(_BAM_SEQ_BASES[(b >> 4) & 0xF])
+        result.append(_BAM_SEQ_BASES[b & 0xF])
+    return "".join(result[:l_seq])
+
+
+def _decode_cigar(data: bytes, n_ops: int) -> str:
+    """Decode BAM CIGAR operations to string like '3S154M6S'."""
+    parts = []
+    for i in range(n_ops):
+        val = struct.unpack("<I", data[i * 4 : i * 4 + 4])[0]
+        parts.append(f"{val >> 4}{_BAM_CIGAR_OPS[val & 0xF]}")
+    return "".join(parts)
+
+
+def _parse_bam_aux_tags(data: bytes) -> Dict[str, Any]:
+    """Parse BAM auxiliary tags."""
+    tags: Dict[str, Any] = {}
+    offset = 0
+    while offset + 3 <= len(data):
+        tag = data[offset : offset + 2].decode("ascii")
+        val_type = chr(data[offset + 2])
+        offset += 3
+
+        if val_type == "A":
+            tags[tag] = chr(data[offset])
+            offset += 1
+        elif val_type == "c":
+            tags[tag] = struct.unpack("<b", data[offset : offset + 1])[0]
+            offset += 1
+        elif val_type == "C":
+            tags[tag] = data[offset]
+            offset += 1
+        elif val_type == "s":
+            tags[tag] = struct.unpack("<h", data[offset : offset + 2])[0]
+            offset += 2
+        elif val_type == "S":
+            tags[tag] = struct.unpack("<H", data[offset : offset + 2])[0]
+            offset += 2
+        elif val_type == "i":
+            tags[tag] = struct.unpack("<i", data[offset : offset + 4])[0]
+            offset += 4
+        elif val_type == "I":
+            tags[tag] = struct.unpack("<I", data[offset : offset + 4])[0]
+            offset += 4
+        elif val_type == "f":
+            tags[tag] = struct.unpack("<f", data[offset : offset + 4])[0]
+            offset += 4
+        elif val_type == "Z":
+            end = data.index(0, offset)
+            tags[tag] = data[offset:end].decode("ascii")
+            offset = end + 1
+        elif val_type == "H":
+            end = data.index(0, offset)
+            tags[tag] = data[offset:end].hex()
+            offset = end + 1
+        else:
+            break
+    return tags
+
+
+def parse_trace_alignment(data: bytes) -> Optional[Dict[str, Any]]:
+    """Parse BGZF-compressed BAM trace alignment data (block 27)."""
+    try:
+        raw = _decompress_bgzf(data)
+    except Exception as e:
+        logger.debug("Failed to decompress BGZF: %s", e)
+        return None
+
+    if len(raw) < 4 or raw[:4] != BAM_MAGIC:
+        logger.debug("Invalid BAM magic")
+        return None
+
+    offset = 4
+    l_text = struct.unpack("<i", raw[offset : offset + 4])[0]
+    offset += 4
+    header = raw[offset : offset + l_text].decode("ascii", errors="ignore")
+    offset += l_text
+
+    n_ref = struct.unpack("<i", raw[offset : offset + 4])[0]
+    offset += 4
+
+    references = []
+    for _ in range(n_ref):
+        l_name = struct.unpack("<i", raw[offset : offset + 4])[0]
+        offset += 4
+        name = raw[offset : offset + l_name - 1].decode("ascii", errors="ignore")
+        offset += l_name
+        l_ref = struct.unpack("<i", raw[offset : offset + 4])[0]
+        offset += 4
+        references.append({"name": name, "length": l_ref})
+
+    records = []
+    while offset + 4 <= len(raw):
+        block_size = struct.unpack("<i", raw[offset : offset + 4])[0]
+        if block_size <= 0:
+            break
+        offset += 4
+        rec_end = offset + block_size
+
+        ref_id = struct.unpack("<i", raw[offset : offset + 4])[0]
+        offset += 4
+        pos = struct.unpack("<i", raw[offset : offset + 4])[0]
+        offset += 4
+
+        bin_mq_nl = struct.unpack("<I", raw[offset : offset + 4])[0]
+        offset += 4
+        l_read_name = bin_mq_nl & 0xFF
+        mapq = (bin_mq_nl >> 8) & 0xFF
+        bam_bin = (bin_mq_nl >> 16) & 0xFFFF
+
+        flag_nc = struct.unpack("<I", raw[offset : offset + 4])[0]
+        offset += 4
+        n_cigar_op = flag_nc & 0xFFFF
+        flag = (flag_nc >> 16) & 0xFFFF
+
+        l_seq = struct.unpack("<i", raw[offset : offset + 4])[0]
+        offset += 4
+        next_ref_id = struct.unpack("<i", raw[offset : offset + 4])[0]
+        offset += 4
+        next_pos = struct.unpack("<i", raw[offset : offset + 4])[0]
+        offset += 4
+        tlen = struct.unpack("<i", raw[offset : offset + 4])[0]
+        offset += 4
+
+        read_name = raw[offset : offset + l_read_name - 1].decode(
+            "ascii", errors="ignore"
+        )
+        offset += l_read_name
+
+        cigar = _decode_cigar(raw[offset : offset + n_cigar_op * 4], n_cigar_op)
+        offset += n_cigar_op * 4
+
+        seq_bytes = (l_seq + 1) // 2
+        sequence = _decode_bam_seq(raw[offset : offset + seq_bytes], l_seq)
+        offset += seq_bytes
+
+        quality = list(raw[offset : offset + l_seq])
+        offset += l_seq
+
+        aux = _parse_bam_aux_tags(raw[offset:rec_end])
+        offset = rec_end
+
+        records.append(
+            {
+                "read_name": read_name,
+                "flag": flag,
+                "ref_id": ref_id,
+                "pos": pos,
+                "mapq": mapq,
+                "cigar": cigar,
+                "sequence": sequence,
+                "quality": quality,
+                "next_ref_id": next_ref_id,
+                "next_pos": next_pos,
+                "tlen": tlen,
+                "bin": bam_bin,
+                "aux": aux,
+            }
+        )
+
+    return {"header": header, "references": references, "records": records}
+
+
+# =============================================================================
 # PARSING SCHEME
 # =============================================================================
 
@@ -591,6 +784,7 @@ SCHEME: Dict[int, Callable] = {
     20: parse_xml,  # Strand colors
     21: parse_sequence,  # Protein
     23: parse_attachment,  # File attachments
+    27: parse_trace_alignment,  # Trace alignment (BGZF BAM)
     28: parse_xml,  # Enzyme visibilities
     29: parse_lzma_xml,  # History modifier
     30: parse_lzma_nested,  # History node content

--- a/src/sgffp/writer.py
+++ b/src/sgffp/writer.py
@@ -154,6 +154,10 @@ class SgffWriter:
         if block_type == 23:
             return self._serialize_attachment(data)
 
+        # Trace alignment (27) - BGZF BAM
+        if block_type == 27:
+            return self._serialize_trace_alignment(data)
+
         # XML blocks with declaration (matches SnapGene behavior)
         if block_type in (5, 14, 28):
             return self._serialize_xml(data, xml_declaration=True)
@@ -312,6 +316,142 @@ class SgffWriter:
             )
 
         raise ValueError(f"Unknown attachment sub-type: {block_subtype}")
+
+    def _serialize_trace_alignment(self, data: Dict) -> bytes:
+        """Serialize trace alignment dict back to BGZF-compressed BAM."""
+        header_text = data.get("header", "")
+        references = data.get("references", [])
+        records = data.get("records", [])
+
+        # Build BAM header block
+        header_buf = BytesIO()
+        header_buf.write(b"BAM\x01")
+        header_bytes = header_text.encode("ascii")
+        header_buf.write(struct.pack("<i", len(header_bytes)))
+        header_buf.write(header_bytes)
+        header_buf.write(struct.pack("<i", len(references)))
+        for ref in references:
+            name = ref.get("name", "")
+            name_bytes = name.encode("ascii") + b"\x00"
+            header_buf.write(struct.pack("<i", len(name_bytes)))
+            header_buf.write(name_bytes)
+            header_buf.write(struct.pack("<i", ref.get("length", 0)))
+        header_data = header_buf.getvalue()
+
+        # Build alignment records
+        records_buf = BytesIO()
+        for rec in records:
+            rec_buf = BytesIO()
+            rec_buf.write(struct.pack("<i", rec.get("ref_id", 0)))
+            rec_buf.write(struct.pack("<i", rec.get("pos", 0)))
+
+            read_name = rec.get("read_name", "")
+            read_name_bytes = read_name.encode("ascii") + b"\x00"
+            l_read_name = len(read_name_bytes)
+
+            cigar_ops = self._encode_cigar(rec.get("cigar", ""))
+            n_cigar_op = len(cigar_ops)
+
+            mapq = rec.get("mapq", 255)
+            bam_bin = rec.get("bin", 0)
+            bin_mq_nl = (bam_bin << 16) | (mapq << 8) | l_read_name
+            rec_buf.write(struct.pack("<I", bin_mq_nl))
+
+            flag = rec.get("flag", 0)
+            flag_nc = (flag << 16) | n_cigar_op
+            rec_buf.write(struct.pack("<I", flag_nc))
+
+            sequence = rec.get("sequence", "")
+            l_seq = len(sequence)
+            rec_buf.write(struct.pack("<i", l_seq))
+            rec_buf.write(struct.pack("<i", rec.get("next_ref_id", 0)))
+            rec_buf.write(struct.pack("<i", rec.get("next_pos", 0)))
+            rec_buf.write(struct.pack("<i", rec.get("tlen", 0)))
+
+            rec_buf.write(read_name_bytes)
+
+            for op in cigar_ops:
+                rec_buf.write(struct.pack("<I", op))
+
+            rec_buf.write(self._encode_bam_seq(sequence))
+
+            quality = rec.get("quality", [])
+            if quality:
+                rec_buf.write(bytes(quality))
+            else:
+                rec_buf.write(b"\xff" * l_seq)
+
+            rec_data = rec_buf.getvalue()
+            records_buf.write(struct.pack("<i", len(rec_data)))
+            records_buf.write(rec_data)
+
+        records_data = records_buf.getvalue()
+
+        # BGZF compress: header block + records block + EOF marker
+        result = BytesIO()
+        result.write(self._bgzf_compress(header_data))
+        if records_data:
+            result.write(self._bgzf_compress(records_data))
+        # EOF marker
+        result.write(
+            b"\x1f\x8b\x08\x04\x00\x00\x00\x00\x00\xff"
+            b"\x06\x00BC\x02\x00\x1b\x00"
+            b"\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+        )
+        return result.getvalue()
+
+    @staticmethod
+    def _encode_cigar(cigar_str: str) -> list:
+        """Encode CIGAR string to list of uint32 BAM CIGAR ops."""
+        import re
+
+        ops_map = {c: i for i, c in enumerate("MIDNSHP=X")}
+        result = []
+        for match in re.finditer(r"(\d+)([MIDNSHP=X])", cigar_str):
+            length = int(match.group(1))
+            op = ops_map[match.group(2)]
+            result.append((length << 4) | op)
+        return result
+
+    @staticmethod
+    def _encode_bam_seq(sequence: str) -> bytes:
+        """Encode sequence string to 4-bit packed BAM format."""
+        seq_map = {c: i for i, c in enumerate("=ACMGRSVTWYHKDBN")}
+        result = bytearray()
+        for i in range(0, len(sequence), 2):
+            high = seq_map.get(sequence[i], 15)
+            low = seq_map.get(sequence[i + 1], 15) if i + 1 < len(sequence) else 0
+            result.append((high << 4) | low)
+        return bytes(result)
+
+    @staticmethod
+    def _bgzf_compress(data: bytes) -> bytes:
+        """Compress data into a single BGZF block."""
+        # Deflate the data
+        compressor = zlib.compressobj(zlib.Z_DEFAULT_COMPRESSION, zlib.DEFLATED, -15)
+        compressed = compressor.compress(data) + compressor.flush()
+
+        # BGZF block: gzip header with BC extra field + compressed + gzip footer
+        bsize = 18 + len(compressed) + 8 - 1  # total block size - 1
+        buf = BytesIO()
+        # Gzip header
+        buf.write(b"\x1f\x8b")  # magic
+        buf.write(b"\x08")  # compression method (deflate)
+        buf.write(b"\x04")  # flags (FEXTRA)
+        buf.write(b"\x00\x00\x00\x00")  # mtime
+        buf.write(b"\x00")  # xfl
+        buf.write(b"\xff")  # OS (unknown)
+        # Extra field
+        buf.write(struct.pack("<H", 6))  # XLEN
+        buf.write(b"BC")  # subfield ID
+        buf.write(struct.pack("<H", 2))  # subfield length
+        buf.write(struct.pack("<H", bsize))  # BSIZE
+        # Compressed data
+        buf.write(compressed)
+        # Gzip footer
+        buf.write(struct.pack("<I", zlib.crc32(data) & 0xFFFFFFFF))
+        buf.write(struct.pack("<I", len(data) & 0xFFFFFFFF))
+        return buf.getvalue()
 
     def _serialize_xml(
         self, data: Dict, *, xml_declaration: bool = False

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -26,6 +26,9 @@ from sgffp.models import (
     SgffTraceList,
     SgffTraceClip,
     SgffTraceSamples,
+    SgffTraceAlignment,
+    SgffBamRecord,
+    SgffBamReference,
 )
 
 
@@ -1971,3 +1974,116 @@ class TestHistoryOperationCategories:
         restored = SgffReader.from_bytes(written)
         assert len(restored.history.tree) == original_count + 2
         assert restored.sequence.value == new_seq
+
+
+# =============================================================================
+# Trace Alignment Model Tests
+# =============================================================================
+
+
+class TestSgffBamReference:
+    def test_from_dict(self):
+        """Create reference from dict"""
+        data = {"name": "reference", "length": 154}
+        ref = SgffBamReference.from_dict(data)
+        assert ref.name == "reference"
+        assert ref.length == 154
+
+    def test_to_dict(self):
+        """Convert reference to dict"""
+        ref = SgffBamReference(name="chr1", length=1000)
+        data = ref.to_dict()
+        assert data["name"] == "chr1"
+        assert data["length"] == 1000
+
+    def test_defaults(self):
+        """Missing values default"""
+        ref = SgffBamReference.from_dict({})
+        assert ref.name == ""
+        assert ref.length == 0
+
+
+class TestSgffBamRecord:
+    def test_from_dict(self):
+        """Create record from dict"""
+        data = {
+            "read_name": "0",
+            "flag": 0,
+            "ref_id": 0,
+            "pos": 0,
+            "mapq": 255,
+            "cigar": "3S154M6S",
+            "sequence": "ATCG",
+            "quality": [255, 255, 255, 255],
+        }
+        rec = SgffBamRecord.from_dict(data)
+        assert rec.read_name == "0"
+        assert rec.cigar == "3S154M6S"
+        assert rec.length == 4
+        assert not rec.is_unmapped
+        assert not rec.is_reverse
+
+    def test_is_unmapped(self):
+        """Flag 0x4 marks unmapped"""
+        rec = SgffBamRecord(flag=4)
+        assert rec.is_unmapped
+
+    def test_is_reverse(self):
+        """Flag 0x10 marks reverse strand"""
+        rec = SgffBamRecord(flag=16)
+        assert rec.is_reverse
+
+    def test_to_dict(self):
+        """Convert record to dict"""
+        rec = SgffBamRecord(read_name="test", cigar="10M", sequence="ATCGATCGAT")
+        data = rec.to_dict()
+        assert data["read_name"] == "test"
+        assert data["cigar"] == "10M"
+
+
+class TestSgffTraceAlignment:
+    def test_empty_blocks(self):
+        """Empty blocks return empty trace alignment"""
+        ta = SgffTraceAlignment({})
+        assert ta.header == ""
+        assert ta.references == []
+        assert ta.records == []
+        assert ta.record_count == 0
+        assert ta.reference_count == 0
+        assert not ta.exists
+
+    def test_load_from_test3(self, test3_dna):
+        """Load trace alignment from test3.dna"""
+        from sgffp.reader import SgffReader
+
+        sgff = SgffReader.from_file(test3_dna)
+        assert sgff.has_trace_alignment
+        ta = sgff.trace_alignment
+        assert ta.exists
+        assert ta.header.startswith("@HD")
+        assert ta.reference_count == 1
+        assert ta.references[0].name == "reference"
+        assert ta.references[0].length == 154
+        assert ta.record_count == 1
+        rec = ta.records[0]
+        assert rec.read_name == "0"
+        assert rec.cigar == "3S154M6S"
+        assert rec.length == 163
+        assert rec.flag == 0
+        assert not rec.is_unmapped
+        assert not rec.is_reverse
+
+    def test_has_trace_alignment_false(self, test_dna):
+        """test.dna has no trace alignment"""
+        from sgffp.reader import SgffReader
+
+        sgff = SgffReader.from_file(test_dna)
+        assert not sgff.has_trace_alignment
+
+    def test_repr(self):
+        """String representation"""
+        blocks = {27: [{"header": "@HD", "references": [{"name": "ref", "length": 100}], "records": []}]}
+        ta = SgffTraceAlignment(blocks)
+        assert "SgffTraceAlignment" in repr(ta)
+        assert "references=1" in repr(ta)
+        assert "records=0" in repr(ta)

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -20,6 +20,7 @@ from sgffp.parsers import (
     parse_features,
     parse_ztr,
     parse_history_node,
+    parse_trace_alignment,
     SCHEME,
     ZTR_MAGIC,
 )
@@ -460,7 +461,7 @@ class TestParseHistoryNode:
 class TestScheme:
     def test_scheme_has_expected_types(self):
         """SCHEME contains all expected block types"""
-        expected = {0, 1, 5, 6, 7, 8, 10, 11, 14, 16, 17, 18, 20, 21, 23, 28, 29, 30, 32, 34}
+        expected = {0, 1, 5, 6, 7, 8, 10, 11, 14, 16, 17, 18, 20, 21, 23, 27, 28, 29, 30, 32, 34}
         assert set(SCHEME.keys()) == expected
 
     def test_scheme_sequence_types(self):
@@ -581,3 +582,43 @@ class TestParseLzmaJson:
         """Invalid data returns None"""
         result = parse_lzma_json(b"not lzma data")
         assert result is None
+
+
+# =============================================================================
+# Trace Alignment (BAM/BGZF) Parser Tests
+# =============================================================================
+
+
+class TestParseTraceAlignment:
+    def test_parse_from_test3(self, test3_dna):
+        """Parse block 27 from test3.dna"""
+        from sgffp.reader import SgffReader
+
+        sgff = SgffReader.from_file(test3_dna)
+        assert 27 in sgff.blocks
+        data = sgff.blocks[27][0]
+        assert data["header"].startswith("@HD")
+        assert len(data["references"]) == 1
+        assert data["references"][0]["name"] == "reference"
+        assert data["references"][0]["length"] == 154
+        assert len(data["records"]) == 1
+        rec = data["records"][0]
+        assert rec["read_name"] == "0"
+        assert rec["cigar"] == "3S154M6S"
+        assert len(rec["sequence"]) == 163
+        assert rec["flag"] == 0
+        assert rec["pos"] == 0
+
+    def test_parse_bad_magic(self):
+        """Non-BGZF data returns None"""
+        result = parse_trace_alignment(b"not bgzf data")
+        assert result is None
+
+    def test_parse_empty(self):
+        """Empty data returns None"""
+        result = parse_trace_alignment(b"")
+        assert result is None
+
+    def test_scheme_has_block_27(self):
+        """Block 27 uses parse_trace_alignment"""
+        assert SCHEME[27] == parse_trace_alignment

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -537,6 +537,51 @@ class TestHistoryRoundtrip:
 # =============================================================================
 
 
+# =============================================================================
+# Block 27 (Trace Alignment) Roundtrip Tests
+# =============================================================================
+
+
+class TestTraceAlignmentRoundtrip:
+    def test_block_27_roundtrip(self, test3_dna):
+        """Block 27 (trace alignment BAM) survives roundtrip"""
+        original = SgffReader.from_file(test3_dna)
+        assert 27 in original.blocks
+
+        written = SgffWriter.to_bytes(original)
+        restored = SgffReader.from_bytes(written)
+
+        assert 27 in restored.blocks
+        orig_ta = original.trace_alignment
+        rest_ta = restored.trace_alignment
+        assert orig_ta.header == rest_ta.header
+        assert orig_ta.reference_count == rest_ta.reference_count
+        assert orig_ta.record_count == rest_ta.record_count
+        for orig_ref, rest_ref in zip(orig_ta.references, rest_ta.references):
+            assert orig_ref.name == rest_ref.name
+            assert orig_ref.length == rest_ref.length
+        for orig_rec, rest_rec in zip(orig_ta.records, rest_ta.records):
+            assert orig_rec.read_name == rest_rec.read_name
+            assert orig_rec.cigar == rest_rec.cigar
+            assert orig_rec.sequence == rest_rec.sequence
+            assert orig_rec.quality == rest_rec.quality
+            assert orig_rec.flag == rest_rec.flag
+            assert orig_rec.pos == rest_rec.pos
+            assert orig_rec.mapq == rest_rec.mapq
+
+    def test_block_27_double_roundtrip_stable(self, test3_dna):
+        """Block 27 output stabilizes after first roundtrip"""
+        original = SgffReader.from_file(test3_dna)
+
+        written1 = SgffWriter.to_bytes(original)
+        restored1 = SgffReader.from_bytes(written1)
+        written2 = SgffWriter.to_bytes(restored1)
+        restored2 = SgffReader.from_bytes(written2)
+        written3 = SgffWriter.to_bytes(restored2)
+
+        assert written2 == written3
+
+
 class TestHistoryModifierRoundtrip:
     def test_seq_type_29_has_modifier(self, circularize_only_dna):
         """History node with seq_type == 29 has a parsed 'modifier' key (not raw bytes)"""


### PR DESCRIPTION
## Summary

- Add full parse/model/write/roundtrip support for block 27 — BGZF-compressed BAM data storing trace-to-reference alignments
- New model: `SgffTraceAlignment`, `SgffBamRecord`, `SgffBamReference` (follows `SgffModel` pattern like `SgffNotes`)
- Parser: BGZF decompression + BAM header/record parsing with CIGAR, 4-bit sequence, quality, aux tags
- Writer: BAM binary encoding + BGZF compression with EOF marker
- CLI: `sff info` now shows trace alignment count; verbose mode shows SAM header, references, per-record details
- Wired into `SgffObject`: `trace_alignment` lazy property, `has_trace_alignment` check, cache invalidation
- 15 new tests (parser, model, roundtrip + double roundtrip stability)
- Docs: format spec, API reference, CLI reference, README block table (16 → 17 blocks)

Block 17 ↔ Block 27 relationship: block 17 (`AlignableSequences` XML) holds alignment metadata (trim range, display settings), block 27 holds the actual BAM data. Linked by ID: block 17's `Sequence/@ID` matches block 27's BAM record `read_name`.

## Test plan

- [x] All 446 tests pass (`make test`)
- [x] `ruff check .` clean
- [x] Roundtrip: test3.dna → write → read → all fields intact
- [x] Double roundtrip: write2 == write3 (output stable)
- [x] `sff info -v tests/data/test3.dna` shows trace alignment details